### PR TITLE
Corrections of paths in gipTensorflow/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,8 @@ set(PLUGIN_LIBS_DIR ${PLUGIN_DIR}/libs)
 
 file(GLOB_RECURSE SOURCES 
 				"${PLUGIN_DIR}/src/*.cpp"
-				"${PLUGIN_DIR}/libs/src/tensorflow/*.cpp"
+				"${PLUGIN_DIR}/libs/src/tensorflow/c/*.c"
+				"${PLUGIN_DIR}/libs/src/tensorflow/cc/*.cc"
 )
 list(APPEND PLUGIN_SRCS ${SOURCES})
 
@@ -22,8 +23,7 @@ list(APPEND PLUGIN_SRCS ${SOURCES})
 list(APPEND PLUGIN_INCLUDES
 			${PLUGIN_DIR}/src
 			${PLUGIN_LIBS_DIR}/include
-			${PLUGIN_LIBS_DIR}/src/tensorflow/c
-			${PLUGIN_LIBS_DIR}/src/tensorflow/cc
+			${PLUGIN_LIBS_DIR}/src
 )
 
 ##### PLUGIN DEPENDENCY LOCATIONS (IF ANY) #####


### PR DESCRIPTION
Some corrections of TensorFlow's paths are made in CMakeLists.txt.